### PR TITLE
Don't reference inspect.getargspec in Python 3.11.

### DIFF
--- a/pyext.py
+++ b/pyext.py
@@ -115,12 +115,14 @@ else:
 def _gettypes(args):
     return tuple(map(type, args))
 
-oargspec = inspect.getargspec
+# Guard 'getargspec' access since it has been removed in Python 3.11.
+if hasattr(inspect, 'getargspec'):
+    oargspec = inspect.getargspec
 
-def _argspec(func):
-    return _targspec(func, oargspec)
+    def _argspec(func):
+        return _targspec(func, oargspec)
 
-inspect.getargspec = _argspec
+    inspect.getargspec = _argspec
 
 try:
     import IPython


### PR DESCRIPTION
This method was removed in Python 3.11.

From https://docs.python.org/3/whatsnew/3.11.html#removed:

> Removed from the [inspect](https://docs.python.org/3/library/inspect.html#module-inspect) module:
> - The getargspec() function, deprecated since Python 3.0; use [inspect.signature()](https://docs.python.org/3/library/inspect.html#inspect.signature) or [inspect.getfullargspec()](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) instead.